### PR TITLE
WIP proof of concept for inlining

### DIFF
--- a/lib/MooseX/Attribute/TypeConstraint/CustomizeFatal.pm
+++ b/lib/MooseX/Attribute/TypeConstraint/CustomizeFatal.pm
@@ -1,3 +1,4 @@
+# snth moosex-attribute-typeconstraint-customizefatal (master=) $ perl5.18.2 -Mblib=../moose -MMoose -Ilib t/basic.t  2>&1 | less -S
 package MooseX::Attribute::TypeConstraint::CustomizeFatal;
 use Moose::Role;
 use MooseX::Types::Moose ':all';
@@ -67,6 +68,26 @@ around _coerce_and_verify => sub {
             die $error;
         }
     };
+};
+
+around _inline_check_constraint => sub {
+    my $orig = shift;
+    my $self = shift;
+
+    my $default = $self->default;
+    my $default_value = ref $default eq 'CODE'
+        # If it's e.g. sub { [] }
+        ? $default->()
+        # It's just a normal SV, e.g. "12345"
+        : $default;
+
+    my (@return) = $self->$orig(@_);
+
+    use Carp qw(longmess);
+
+    use Data::Dumper;
+    print STDERR longmess(Dumper(\@return));
+    return @return;
 };
 
 package Moose::Meta::Attribute::Custom::Trait::TypeConstraint::CustomizeFatal;


### PR DESCRIPTION
We need change this stuff and munge it with "around" methods and whatnot
inline these things. The source for the stuff we're munging is in
Moose::Meta::Attribute:
https://metacpan.org/source/ETHER/Moose-2.1403/lib/Moose/Meta/Attribute.pm#L678

We need to:

 * Do the type check
 * If it fails get our attributes's config for it
 * Get the default value if needed (for the fallback to default)
 * Munge the current
   Moose::Exception::ValidationFailedForInlineTypeConstraint to warn or
   whatever.
 * For bonus points group this all into one warning/error at the end
   instead of one per attribute.

I asked on #moose-dev and evidently the best way to debug this generated
code is to just do this shit, i.e. dump it out to STDERR.

This is what you get if you run the command I've added as a comment to
the top of lib/MooseX/Attribute/TypeConstraint/CustomizeFatal.pm:

    1..15
    $VAR1 = [
              'if (! (( do { ( do { ( do { defined($params->{\'a\'}) } ) && !ref($params->{\'a\'}) } ) && (my $val = $params->{\'a\'}) =~ /\\A-?[0-9]+\\z/ } ))) {',
              'my $msg = do { local $_ = $params->{\'a\'}; $type_constraint_messages[0]->($params->{\'a\'});};
    die Module::Runtime::use_module("Moose::Exception::ValidationFailedForInlineTypeConstraint")->new(type_constraint_message => $msg , class_name              => $class_name, attribute_name          => "a",value                   => $params->{\'a\'});',
              '}'
            ];
     at ../moose/blib/lib/Class/MOP/Method/Wrapped.pm line 158.
    	Class::MOP::Method::Wrapped::__ANON__(Moose::Meta::Class::__ANON__::SERIAL::1=HASH(0x2d57560), "\$params->{'a'}", "\$type_constraint_bodies[0]", "\$type_constraint_messages[0]", undef) called at ../moose/blib/lib/Class/MOP/Method/Wrapped.pm line 87
    	Moose::Meta::Class::__ANON__::SERIAL::1::_inline_check_constraint(Moose::Meta::Class::__ANON__::SERIAL::1=HASH(0x2d57560), "\$params->{'a'}", "\$type_constraint_bodies[0]", "\$type_constraint_messages[0]", undef) called at ../moose/blib/lib/Moose/Meta/Attribute.pm line 650
    	Moose::Meta::Attribute::_inline_tc_code(Moose::Meta::Class::__ANON__::SERIAL::1=HASH(0x2d57560), "\$params->{'a'}", "\$type_constraint_bodies[0]", "\$type_coercions[0]", "\$type_constraint_messages[0]") called at ../moose/blib/lib/Moose/Meta/Attribute.pm line 596
    	Moose::Meta::Attribute::_inline_set_value(Moose::Meta::Class::__ANON__::SERIAL::1=HASH(0x2d57560), "\$instance", "\$params->{'a'}", "\$type_constraint_bodies[0]", "\$type_coercions[0]", "\$type_constraint_messages[0]", "for constructor") called at ../moose/blib/lib/Moose/Meta/Class.pm line 398
    	Moose::Meta::Class::_inline_init_attr_from_constructor(Moose::Meta::Class=HASH(0x2d57938), Moose::Meta::Class::__ANON__::SERIAL::1=HASH(0x2d57560), 0) called at ../moose/blib/lib/Class/MOP/Class.pm line 601
    	Class::MOP::Class::_inline_slot_initializer(Moose::Meta::Class=HASH(0x2d57938), Moose::Meta::Class::__ANON__::SERIAL::1=HASH(0x2d57560), 0) called at ../moose/blib/lib/Moose/Meta/Class.pm line 365
    	Moose::Meta::Class::_inline_slot_initializer(Moose::Meta::Class=HASH(0x2d57938), Moose::Meta::Class::__ANON__::SERIAL::1=HASH(0x2d57560), 0) called at ../moose/blib/lib/Class/MOP/Class.pm line 592
    	Class::MOP::Class::_inline_slot_initializers(Moose::Meta::Class=HASH(0x2d57938)) called at ../moose/blib/lib/Class/MOP/Class.pm line 538
    	Class::MOP::Class::_inline_new_object(Moose::Meta::Class=HASH(0x2d57938)) called at ../moose/blib/lib/Class/MOP/Method/Constructor.pm line 98
    	Class::MOP::Method::Constructor::_generate_constructor_method_inline(Moose::Meta::Method::Constructor=HASH(0x2d577d0)) called at ../moose/blib/lib/Moose/Meta/Method/Constructor.pm line 54
    	Moose::Meta::Method::Constructor::_initialize_body(Moose::Meta::Method::Constructor=HASH(0x2d577d0)) called at ../moose/blib/lib/Moose/Meta/Method/Constructor.pm line 45
    	Moose::Meta::Method::Constructor::new("Moose::Meta::Method::Constructor", "options", HASH(0x295f150), "metaclass", Moose::Meta::Class=HASH(0x2d57938), "is_inline", 1, "package_name", "ImmutableClass", ...) called at ../moose/blib/lib/Class/MOP/Class.pm line 1453
    	Class::MOP::Class::_inline_constructor(Moose::Meta::Class=HASH(0x2d57938), "constructor_class", "Moose::Meta::Method::Constructor", "line", 36, "inline_destructor", 1, "constructor_name", "new", ...) called at ../moose/blib/lib/Class/MOP/Class.pm line 1409
    	Class::MOP::Class::_install_inlined_code(Moose::Meta::Class=HASH(0x2d57938), "immutable_trait", "Class::MOP::Class::Immutable::Trait", "inline_constructor", 1, "inline_accessors", 0, "debug", 0, ...) called at ../moose/blib/lib/Class/MOP/Class.pm line 1401
    	Class::MOP::Class::_initialize_immutable(Moose::Meta::Class=HASH(0x2d57938), "file", "t/basic.t", "line", 36, "inline_accessors", 1, "inline_constructor", 1, ...) called at ../moose/blib/lib/Class/MOP/Class.pm line 1297
    	Class::MOP::Class::make_immutable(Moose::Meta::Class=HASH(0x2d57938)) called at t/basic.t line 36
    $VAR1 = [
              'if (! (( do { ( do { ( do { defined($default) } ) && !ref($default) } ) && (my $val = $default) =~ /\\A-?[0-9]+\\z/ } ))) {',
              'my $msg = do { local $_ = $default; $type_constraint_messages[0]->($default);};
    die Module::Runtime::use_module("Moose::Exception::ValidationFailedForInlineTypeConstraint")->new(type_constraint_message => $msg , class_name              => $class_name, attribute_name          => "a",value                   => $default);',
              '}'
            ];
     at ../moose/blib/lib/Class/MOP/Method/Wrapped.pm line 158.
    	Class::MOP::Method::Wrapped::__ANON__(Moose::Meta::Class::__ANON__::SERIAL::1=HASH(0x2d57560), "\$default", "\$type_constraint_bodies[0]", "\$type_constraint_messages[0]", undef) called at ../moose/blib/lib/Class/MOP/Method/Wrapped.pm line 87
    	Moose::Meta::Class::__ANON__::SERIAL::1::_inline_check_constraint(Moose::Meta::Class::__ANON__::SERIAL::1=HASH(0x2d57560), "\$default", "\$type_constraint_bodies[0]", "\$type_constraint_messages[0]", undef) called at ../moose/blib/lib/Moose/Meta/Attribute.pm line 650
    	Moose::Meta::Attribute::_inline_tc_code(Moose::Meta::Class::__ANON__::SERIAL::1=HASH(0x2d57560), "\$default", "\$type_constraint_bodies[0]", "\$type_coercions[0]", "\$type_constraint_messages[0]") called at ../moose/blib/lib/Moose/Meta/Attribute.pm line 596
    	Moose::Meta::Attribute::_inline_set_value(Moose::Meta::Class::__ANON__::SERIAL::1=HASH(0x2d57560), "\$instance", "\$default", "\$type_constraint_bodies[0]", "\$type_coercions[0]", "\$type_constraint_messages[0]", "for constructor") called at ../moose/blib/lib/Moose/Meta/Class.pm line 425
    	Moose::Meta::Class::_inline_init_attr_from_default(Moose::Meta::Class=HASH(0x2d57938), Moose::Meta::Class::__ANON__::SERIAL::1=HASH(0x2d57560), 0) called at ../moose/blib/lib/Class/MOP/Class.pm line 606
    	Class::MOP::Class::_inline_slot_initializer(Moose::Meta::Class=HASH(0x2d57938), Moose::Meta::Class::__ANON__::SERIAL::1=HASH(0x2d57560), 0) called at ../moose/blib/lib/Moose/Meta/Class.pm line 365
    	Moose::Meta::Class::_inline_slot_initializer(Moose::Meta::Class=HASH(0x2d57938), Moose::Meta::Class::__ANON__::SERIAL::1=HASH(0x2d57560), 0) called at ../moose/blib/lib/Class/MOP/Class.pm line 592
    	Class::MOP::Class::_inline_slot_initializers(Moose::Meta::Class=HASH(0x2d57938)) called at ../moose/blib/lib/Class/MOP/Class.pm line 538
    	Class::MOP::Class::_inline_new_object(Moose::Meta::Class=HASH(0x2d57938)) called at ../moose/blib/lib/Class/MOP/Method/Constructor.pm line 98
    	Class::MOP::Method::Constructor::_generate_constructor_method_inline(Moose::Meta::Method::Constructor=HASH(0x2d577d0)) called at ../moose/blib/lib/Moose/Meta/Method/Constructor.pm line 54
    	Moose::Meta::Method::Constructor::_initialize_body(Moose::Meta::Method::Constructor=HASH(0x2d577d0)) called at ../moose/blib/lib/Moose/Meta/Method/Constructor.pm line 45
    	Moose::Meta::Method::Constructor::new("Moose::Meta::Method::Constructor", "options", HASH(0x295f150), "metaclass", Moose::Meta::Class=HASH(0x2d57938), "is_inline", 1, "package_name", "ImmutableClass", ...) called at ../moose/blib/lib/Class/MOP/Class.pm line 1453
    	Class::MOP::Class::_inline_constructor(Moose::Meta::Class=HASH(0x2d57938), "constructor_class", "Moose::Meta::Method::Constructor", "line", 36, "inline_destructor", 1, "constructor_name", "new", ...) called at ../moose/blib/lib/Class/MOP/Class.pm line 1409
    	Class::MOP::Class::_install_inlined_code(Moose::Meta::Class=HASH(0x2d57938), "immutable_trait", "Class::MOP::Class::Immutable::Trait", "inline_constructor", 1, "inline_accessors", 0, "debug", 0, ...) called at ../moose/blib/lib/Class/MOP/Class.pm line 1401
    	Class::MOP::Class::_initialize_immutable(Moose::Meta::Class=HASH(0x2d57938), "file", "t/basic.t", "line", 36, "inline_accessors", 1, "inline_constructor", 1, ...) called at ../moose/blib/lib/Class/MOP/Class.pm line 1297
    	Class::MOP::Class::make_immutable(Moose::Meta::Class=HASH(0x2d57938)) called at t/basic.t line 36
    $VAR1 = [
              'if (! (( do { ( do { ( do { defined($params->{\'b\'}) } ) && !ref($params->{\'b\'}) } ) && (my $val = $params->{\'b\'}) =~ /\\A-?[0-9]+\\z/ } ))) {',
              'my $msg = do { local $_ = $params->{\'b\'}; $type_constraint_messages[1]->($params->{\'b\'});};
    die Module::Runtime::use_module("Moose::Exception::ValidationFailedForInlineTypeConstraint")->new(type_constraint_message => $msg , class_name              => $class_name, attribute_name          => "b",value                   => $params->{\'b\'});',
              '}'
            ];
     at ../moose/blib/lib/Class/MOP/Method/Wrapped.pm line 158.
    	Class::MOP::Method::Wrapped::__ANON__(Moose::Meta::Class::__ANON__::SERIAL::1=HASH(0x2d577b8), "\$params->{'b'}", "\$type_constraint_bodies[1]", "\$type_constraint_messages[1]", undef) called at ../moose/blib/lib/Class/MOP/Method/Wrapped.pm line 87
    	Moose::Meta::Class::__ANON__::SERIAL::1::_inline_check_constraint(Moose::Meta::Class::__ANON__::SERIAL::1=HASH(0x2d577b8), "\$params->{'b'}", "\$type_constraint_bodies[1]", "\$type_constraint_messages[1]", undef) called at ../moose/blib/lib/Moose/Meta/Attribute.pm line 650
    	Moose::Meta::Attribute::_inline_tc_code(Moose::Meta::Class::__ANON__::SERIAL::1=HASH(0x2d577b8), "\$params->{'b'}", "\$type_constraint_bodies[1]", "\$type_coercions[1]", "\$type_constraint_messages[1]") called at ../moose/blib/lib/Moose/Meta/Attribute.pm line 596
    	Moose::Meta::Attribute::_inline_set_value(Moose::Meta::Class::__ANON__::SERIAL::1=HASH(0x2d577b8), "\$instance", "\$params->{'b'}", "\$type_constraint_bodies[1]", "\$type_coercions[1]", "\$type_constraint_messages[1]", "for constructor") called at ../moose/blib/lib/Moose/Meta/Class.pm line 398
    	Moose::Meta::Class::_inline_init_attr_from_constructor(Moose::Meta::Class=HASH(0x2d57938), Moose::Meta::Class::__ANON__::SERIAL::1=HASH(0x2d577b8), 1) called at ../moose/blib/lib/Class/MOP/Class.pm line 601
    	Class::MOP::Class::_inline_slot_initializer(Moose::Meta::Class=HASH(0x2d57938), Moose::Meta::Class::__ANON__::SERIAL::1=HASH(0x2d577b8), 1) called at ../moose/blib/lib/Moose/Meta/Class.pm line 365
    	Moose::Meta::Class::_inline_slot_initializer(Moose::Meta::Class=HASH(0x2d57938), Moose::Meta::Class::__ANON__::SERIAL::1=HASH(0x2d577b8), 1) called at ../moose/blib/lib/Class/MOP/Class.pm line 592
    	Class::MOP::Class::_inline_slot_initializers(Moose::Meta::Class=HASH(0x2d57938)) called at ../moose/blib/lib/Class/MOP/Class.pm line 538
    	Class::MOP::Class::_inline_new_object(Moose::Meta::Class=HASH(0x2d57938)) called at ../moose/blib/lib/Class/MOP/Method/Constructor.pm line 98
    	Class::MOP::Method::Constructor::_generate_constructor_method_inline(Moose::Meta::Method::Constructor=HASH(0x2d577d0)) called at ../moose/blib/lib/Moose/Meta/Method/Constructor.pm line 54
    	Moose::Meta::Method::Constructor::_initialize_body(Moose::Meta::Method::Constructor=HASH(0x2d577d0)) called at ../moose/blib/lib/Moose/Meta/Method/Constructor.pm line 45
    	Moose::Meta::Method::Constructor::new("Moose::Meta::Method::Constructor", "options", HASH(0x295f150), "metaclass", Moose::Meta::Class=HASH(0x2d57938), "is_inline", 1, "package_name", "ImmutableClass", ...) called at ../moose/blib/lib/Class/MOP/Class.pm line 1453
    	Class::MOP::Class::_inline_constructor(Moose::Meta::Class=HASH(0x2d57938), "constructor_class", "Moose::Meta::Method::Constructor", "line", 36, "inline_destructor", 1, "constructor_name", "new", ...) called at ../moose/blib/lib/Class/MOP/Class.pm line 1409
    	Class::MOP::Class::_install_inlined_code(Moose::Meta::Class=HASH(0x2d57938), "immutable_trait", "Class::MOP::Class::Immutable::Trait", "inline_constructor", 1, "inline_accessors", 0, "debug", 0, ...) called at ../moose/blib/lib/Class/MOP/Class.pm line 1401
    	Class::MOP::Class::_initialize_immutable(Moose::Meta::Class=HASH(0x2d57938), "file", "t/basic.t", "line", 36, "inline_accessors", 1, "inline_constructor", 1, ...) called at ../moose/blib/lib/Class/MOP/Class.pm line 1297
    	Class::MOP::Class::make_immutable(Moose::Meta::Class=HASH(0x2d57938)) called at t/basic.t line 36
    $VAR1 = [
              'if (! (( do { ( do { ( do { defined($default) } ) && !ref($default) } ) && (my $val = $default) =~ /\\A-?[0-9]+\\z/ } ))) {',
              'my $msg = do { local $_ = $default; $type_constraint_messages[1]->($default);};
    die Module::Runtime::use_module("Moose::Exception::ValidationFailedForInlineTypeConstraint")->new(type_constraint_message => $msg , class_name              => $class_name, attribute_name          => "b",value                   => $default);',
              '}'
            ];
     at ../moose/blib/lib/Class/MOP/Method/Wrapped.pm line 158.
    	Class::MOP::Method::Wrapped::__ANON__(Moose::Meta::Class::__ANON__::SERIAL::1=HASH(0x2d577b8), "\$default", "\$type_constraint_bodies[1]", "\$type_constraint_messages[1]", undef) called at ../moose/blib/lib/Class/MOP/Method/Wrapped.pm line 87
    	Moose::Meta::Class::__ANON__::SERIAL::1::_inline_check_constraint(Moose::Meta::Class::__ANON__::SERIAL::1=HASH(0x2d577b8), "\$default", "\$type_constraint_bodies[1]", "\$type_constraint_messages[1]", undef) called at ../moose/blib/lib/Moose/Meta/Attribute.pm line 650
    	Moose::Meta::Attribute::_inline_tc_code(Moose::Meta::Class::__ANON__::SERIAL::1=HASH(0x2d577b8), "\$default", "\$type_constraint_bodies[1]", "\$type_coercions[1]", "\$type_constraint_messages[1]") called at ../moose/blib/lib/Moose/Meta/Attribute.pm line 596
    	Moose::Meta::Attribute::_inline_set_value(Moose::Meta::Class::__ANON__::SERIAL::1=HASH(0x2d577b8), "\$instance", "\$default", "\$type_constraint_bodies[1]", "\$type_coercions[1]", "\$type_constraint_messages[1]", "for constructor") called at ../moose/blib/lib/Moose/Meta/Class.pm line 425
    	Moose::Meta::Class::_inline_init_attr_from_default(Moose::Meta::Class=HASH(0x2d57938), Moose::Meta::Class::__ANON__::SERIAL::1=HASH(0x2d577b8), 1) called at ../moose/blib/lib/Class/MOP/Class.pm line 606
    	Class::MOP::Class::_inline_slot_initializer(Moose::Meta::Class=HASH(0x2d57938), Moose::Meta::Class::__ANON__::SERIAL::1=HASH(0x2d577b8), 1) called at ../moose/blib/lib/Moose/Meta/Class.pm line 365
    	Moose::Meta::Class::_inline_slot_initializer(Moose::Meta::Class=HASH(0x2d57938), Moose::Meta::Class::__ANON__::SERIAL::1=HASH(0x2d577b8), 1) called at ../moose/blib/lib/Class/MOP/Class.pm line 592
    	Class::MOP::Class::_inline_slot_initializers(Moose::Meta::Class=HASH(0x2d57938)) called at ../moose/blib/lib/Class/MOP/Class.pm line 538
    	Class::MOP::Class::_inline_new_object(Moose::Meta::Class=HASH(0x2d57938)) called at ../moose/blib/lib/Class/MOP/Method/Constructor.pm line 98
    	Class::MOP::Method::Constructor::_generate_constructor_method_inline(Moose::Meta::Method::Constructor=HASH(0x2d577d0)) called at ../moose/blib/lib/Moose/Meta/Method/Constructor.pm line 54
    	Moose::Meta::Method::Constructor::_initialize_body(Moose::Meta::Method::Constructor=HASH(0x2d577d0)) called at ../moose/blib/lib/Moose/Meta/Method/Constructor.pm line 45
    	Moose::Meta::Method::Constructor::new("Moose::Meta::Method::Constructor", "options", HASH(0x295f150), "metaclass", Moose::Meta::Class=HASH(0x2d57938), "is_inline", 1, "package_name", "ImmutableClass", ...) called at ../moose/blib/lib/Class/MOP/Class.pm line 1453
    	Class::MOP::Class::_inline_constructor(Moose::Meta::Class=HASH(0x2d57938), "constructor_class", "Moose::Meta::Method::Constructor", "line", 36, "inline_destructor", 1, "constructor_name", "new", ...) called at ../moose/blib/lib/Class/MOP/Class.pm line 1409
    	Class::MOP::Class::_install_inlined_code(Moose::Meta::Class=HASH(0x2d57938), "immutable_trait", "Class::MOP::Class::Immutable::Trait", "inline_constructor", 1, "inline_accessors", 0, "debug", 0, ...) called at ../moose/blib/lib/Class/MOP/Class.pm line 1401
    	Class::MOP::Class::_initialize_immutable(Moose::Meta::Class=HASH(0x2d57938), "file", "t/basic.t", "line", 36, "inline_accessors", 1, "inline_constructor", 1, ...) called at ../moose/blib/lib/Class/MOP/Class.pm line 1297
    	Class::MOP::Class::make_immutable(Moose::Meta::Class=HASH(0x2d57938)) called at t/basic.t line 36
    $VAR1 = [
              'if (! (( do { ( do { ( do { defined($params->{\'c\'}) } ) && !ref($params->{\'c\'}) } ) && (my $val = $params->{\'c\'}) =~ /\\A-?[0-9]+\\z/ } ))) {',
              'my $msg = do { local $_ = $params->{\'c\'}; $type_constraint_messages[2]->($params->{\'c\'});};
    die Module::Runtime::use_module("Moose::Exception::ValidationFailedForInlineTypeConstraint")->new(type_constraint_message => $msg , class_name              => $class_name, attribute_name          => "c",value                   => $params->{\'c\'});',
              '}'
            ];
     at ../moose/blib/lib/Class/MOP/Method/Wrapped.pm line 158.
    	Class::MOP::Method::Wrapped::__ANON__(Moose::Meta::Class::__ANON__::SERIAL::1=HASH(0x2d574d0), "\$params->{'c'}", "\$type_constraint_bodies[2]", "\$type_constraint_messages[2]", undef) called at ../moose/blib/lib/Class/MOP/Method/Wrapped.pm line 87
    	Moose::Meta::Class::__ANON__::SERIAL::1::_inline_check_constraint(Moose::Meta::Class::__ANON__::SERIAL::1=HASH(0x2d574d0), "\$params->{'c'}", "\$type_constraint_bodies[2]", "\$type_constraint_messages[2]", undef) called at ../moose/blib/lib/Moose/Meta/Attribute.pm line 650
    	Moose::Meta::Attribute::_inline_tc_code(Moose::Meta::Class::__ANON__::SERIAL::1=HASH(0x2d574d0), "\$params->{'c'}", "\$type_constraint_bodies[2]", "\$type_coercions[2]", "\$type_constraint_messages[2]") called at ../moose/blib/lib/Moose/Meta/Attribute.pm line 596
    	Moose::Meta::Attribute::_inline_set_value(Moose::Meta::Class::__ANON__::SERIAL::1=HASH(0x2d574d0), "\$instance", "\$params->{'c'}", "\$type_constraint_bodies[2]", "\$type_coercions[2]", "\$type_constraint_messages[2]", "for constructor") called at ../moose/blib/lib/Moose/Meta/Class.pm line 398
    	Moose::Meta::Class::_inline_init_attr_from_constructor(Moose::Meta::Class=HASH(0x2d57938), Moose::Meta::Class::__ANON__::SERIAL::1=HASH(0x2d574d0), 2) called at ../moose/blib/lib/Class/MOP/Class.pm line 601
    	Class::MOP::Class::_inline_slot_initializer(Moose::Meta::Class=HASH(0x2d57938), Moose::Meta::Class::__ANON__::SERIAL::1=HASH(0x2d574d0), 2) called at ../moose/blib/lib/Moose/Meta/Class.pm line 365
    	Moose::Meta::Class::_inline_slot_initializer(Moose::Meta::Class=HASH(0x2d57938), Moose::Meta::Class::__ANON__::SERIAL::1=HASH(0x2d574d0), 2) called at ../moose/blib/lib/Class/MOP/Class.pm line 592
    	Class::MOP::Class::_inline_slot_initializers(Moose::Meta::Class=HASH(0x2d57938)) called at ../moose/blib/lib/Class/MOP/Class.pm line 538
    	Class::MOP::Class::_inline_new_object(Moose::Meta::Class=HASH(0x2d57938)) called at ../moose/blib/lib/Class/MOP/Method/Constructor.pm line 98
    	Class::MOP::Method::Constructor::_generate_constructor_method_inline(Moose::Meta::Method::Constructor=HASH(0x2d577d0)) called at ../moose/blib/lib/Moose/Meta/Method/Constructor.pm line 54
    	Moose::Meta::Method::Constructor::_initialize_body(Moose::Meta::Method::Constructor=HASH(0x2d577d0)) called at ../moose/blib/lib/Moose/Meta/Method/Constructor.pm line 45
    	Moose::Meta::Method::Constructor::new("Moose::Meta::Method::Constructor", "options", HASH(0x295f150), "metaclass", Moose::Meta::Class=HASH(0x2d57938), "is_inline", 1, "package_name", "ImmutableClass", ...) called at ../moose/blib/lib/Class/MOP/Class.pm line 1453
    	Class::MOP::Class::_inline_constructor(Moose::Meta::Class=HASH(0x2d57938), "constructor_class", "Moose::Meta::Method::Constructor", "line", 36, "inline_destructor", 1, "constructor_name", "new", ...) called at ../moose/blib/lib/Class/MOP/Class.pm line 1409
    	Class::MOP::Class::_install_inlined_code(Moose::Meta::Class=HASH(0x2d57938), "immutable_trait", "Class::MOP::Class::Immutable::Trait", "inline_constructor", 1, "inline_accessors", 0, "debug", 0, ...) called at ../moose/blib/lib/Class/MOP/Class.pm line 1401
    	Class::MOP::Class::_initialize_immutable(Moose::Meta::Class=HASH(0x2d57938), "file", "t/basic.t", "line", 36, "inline_accessors", 1, "inline_constructor", 1, ...) called at ../moose/blib/lib/Class/MOP/Class.pm line 1297
    	Class::MOP::Class::make_immutable(Moose::Meta::Class=HASH(0x2d57938)) called at t/basic.t line 36
    $VAR1 = [
              'if (! (( do { ( do { ( do { defined($default) } ) && !ref($default) } ) && (my $val = $default) =~ /\\A-?[0-9]+\\z/ } ))) {',
              'my $msg = do { local $_ = $default; $type_constraint_messages[2]->($default);};
    die Module::Runtime::use_module("Moose::Exception::ValidationFailedForInlineTypeConstraint")->new(type_constraint_message => $msg , class_name              => $class_name, attribute_name          => "c",value                   => $default);',
              '}'
            ];
     at ../moose/blib/lib/Class/MOP/Method/Wrapped.pm line 158.
    	Class::MOP::Method::Wrapped::__ANON__(Moose::Meta::Class::__ANON__::SERIAL::1=HASH(0x2d574d0), "\$default", "\$type_constraint_bodies[2]", "\$type_constraint_messages[2]", undef) called at ../moose/blib/lib/Class/MOP/Method/Wrapped.pm line 87
    	Moose::Meta::Class::__ANON__::SERIAL::1::_inline_check_constraint(Moose::Meta::Class::__ANON__::SERIAL::1=HASH(0x2d574d0), "\$default", "\$type_constraint_bodies[2]", "\$type_constraint_messages[2]", undef) called at ../moose/blib/lib/Moose/Meta/Attribute.pm line 650
    	Moose::Meta::Attribute::_inline_tc_code(Moose::Meta::Class::__ANON__::SERIAL::1=HASH(0x2d574d0), "\$default", "\$type_constraint_bodies[2]", "\$type_coercions[2]", "\$type_constraint_messages[2]") called at ../moose/blib/lib/Moose/Meta/Attribute.pm line 596
    	Moose::Meta::Attribute::_inline_set_value(Moose::Meta::Class::__ANON__::SERIAL::1=HASH(0x2d574d0), "\$instance", "\$default", "\$type_constraint_bodies[2]", "\$type_coercions[2]", "\$type_constraint_messages[2]", "for constructor") called at ../moose/blib/lib/Moose/Meta/Class.pm line 425
    	Moose::Meta::Class::_inline_init_attr_from_default(Moose::Meta::Class=HASH(0x2d57938), Moose::Meta::Class::__ANON__::SERIAL::1=HASH(0x2d574d0), 2) called at ../moose/blib/lib/Class/MOP/Class.pm line 606
    	Class::MOP::Class::_inline_slot_initializer(Moose::Meta::Class=HASH(0x2d57938), Moose::Meta::Class::__ANON__::SERIAL::1=HASH(0x2d574d0), 2) called at ../moose/blib/lib/Moose/Meta/Class.pm line 365
    	Moose::Meta::Class::_inline_slot_initializer(Moose::Meta::Class=HASH(0x2d57938), Moose::Meta::Class::__ANON__::SERIAL::1=HASH(0x2d574d0), 2) called at ../moose/blib/lib/Class/MOP/Class.pm line 592
    	Class::MOP::Class::_inline_slot_initializers(Moose::Meta::Class=HASH(0x2d57938)) called at ../moose/blib/lib/Class/MOP/Class.pm line 538
    	Class::MOP::Class::_inline_new_object(Moose::Meta::Class=HASH(0x2d57938)) called at ../moose/blib/lib/Class/MOP/Method/Constructor.pm line 98
    	Class::MOP::Method::Constructor::_generate_constructor_method_inline(Moose::Meta::Method::Constructor=HASH(0x2d577d0)) called at ../moose/blib/lib/Moose/Meta/Method/Constructor.pm line 54
    	Moose::Meta::Method::Constructor::_initialize_body(Moose::Meta::Method::Constructor=HASH(0x2d577d0)) called at ../moose/blib/lib/Moose/Meta/Method/Constructor.pm line 45
    	Moose::Meta::Method::Constructor::new("Moose::Meta::Method::Constructor", "options", HASH(0x295f150), "metaclass", Moose::Meta::Class=HASH(0x2d57938), "is_inline", 1, "package_name", "ImmutableClass", ...) called at ../moose/blib/lib/Class/MOP/Class.pm line 1453
    	Class::MOP::Class::_inline_constructor(Moose::Meta::Class=HASH(0x2d57938), "constructor_class", "Moose::Meta::Method::Constructor", "line", 36, "inline_destructor", 1, "constructor_name", "new", ...) called at ../moose/blib/lib/Class/MOP/Class.pm line 1409
    	Class::MOP::Class::_install_inlined_code(Moose::Meta::Class=HASH(0x2d57938), "immutable_trait", "Class::MOP::Class::Immutable::Trait", "inline_constructor", 1, "inline_accessors", 0, "debug", 0, ...) called at ../moose/blib/lib/Class/MOP/Class.pm line 1401
    	Class::MOP::Class::_initialize_immutable(Moose::Meta::Class=HASH(0x2d57938), "file", "t/basic.t", "line", 36, "inline_accessors", 1, "inline_constructor", 1, ...) called at ../moose/blib/lib/Class/MOP/Class.pm line 1297
    	Class::MOP::Class::make_immutable(Moose::Meta::Class=HASH(0x2d57938)) called at t/basic.t line 36
    $VAR1 = [
              'if (! (( do { ( do { ( do { defined($params->{\'d\'}) } ) && !ref($params->{\'d\'}) } ) && (my $val = $params->{\'d\'}) =~ /\\A-?[0-9]+\\z/ } ))) {',
              'my $msg = do { local $_ = $params->{\'d\'}; $type_constraint_messages[3]->($params->{\'d\'});};
    die Module::Runtime::use_module("Moose::Exception::ValidationFailedForInlineTypeConstraint")->new(type_constraint_message => $msg , class_name              => $class_name, attribute_name          => "d",value                   => $params->{\'d\'});',
              '}'
            ];
     at ../moose/blib/lib/Class/MOP/Method/Wrapped.pm line 158.
    	Class::MOP::Method::Wrapped::__ANON__(Moose::Meta::Class::__ANON__::SERIAL::1=HASH(0x2d65190), "\$params->{'d'}", "\$type_constraint_bodies[3]", "\$type_constraint_messages[3]", undef) called at ../moose/blib/lib/Class/MOP/Method/Wrapped.pm line 87
    	Moose::Meta::Class::__ANON__::SERIAL::1::_inline_check_constraint(Moose::Meta::Class::__ANON__::SERIAL::1=HASH(0x2d65190), "\$params->{'d'}", "\$type_constraint_bodies[3]", "\$type_constraint_messages[3]", undef) called at ../moose/blib/lib/Moose/Meta/Attribute.pm line 650
    	Moose::Meta::Attribute::_inline_tc_code(Moose::Meta::Class::__ANON__::SERIAL::1=HASH(0x2d65190), "\$params->{'d'}", "\$type_constraint_bodies[3]", "\$type_coercions[3]", "\$type_constraint_messages[3]") called at ../moose/blib/lib/Moose/Meta/Attribute.pm line 596
    	Moose::Meta::Attribute::_inline_set_value(Moose::Meta::Class::__ANON__::SERIAL::1=HASH(0x2d65190), "\$instance", "\$params->{'d'}", "\$type_constraint_bodies[3]", "\$type_coercions[3]", "\$type_constraint_messages[3]", "for constructor") called at ../moose/blib/lib/Moose/Meta/Class.pm line 398
    	Moose::Meta::Class::_inline_init_attr_from_constructor(Moose::Meta::Class=HASH(0x2d57938), Moose::Meta::Class::__ANON__::SERIAL::1=HASH(0x2d65190), 3) called at ../moose/blib/lib/Class/MOP/Class.pm line 601
    	Class::MOP::Class::_inline_slot_initializer(Moose::Meta::Class=HASH(0x2d57938), Moose::Meta::Class::__ANON__::SERIAL::1=HASH(0x2d65190), 3) called at ../moose/blib/lib/Moose/Meta/Class.pm line 365
    	Moose::Meta::Class::_inline_slot_initializer(Moose::Meta::Class=HASH(0x2d57938), Moose::Meta::Class::__ANON__::SERIAL::1=HASH(0x2d65190), 3) called at ../moose/blib/lib/Class/MOP/Class.pm line 592
    	Class::MOP::Class::_inline_slot_initializers(Moose::Meta::Class=HASH(0x2d57938)) called at ../moose/blib/lib/Class/MOP/Class.pm line 538
    	Class::MOP::Class::_inline_new_object(Moose::Meta::Class=HASH(0x2d57938)) called at ../moose/blib/lib/Class/MOP/Method/Constructor.pm line 98
    	Class::MOP::Method::Constructor::_generate_constructor_method_inline(Moose::Meta::Method::Constructor=HASH(0x2d577d0)) called at ../moose/blib/lib/Moose/Meta/Method/Constructor.pm line 54
    	Moose::Meta::Method::Constructor::_initialize_body(Moose::Meta::Method::Constructor=HASH(0x2d577d0)) called at ../moose/blib/lib/Moose/Meta/Method/Constructor.pm line 45
    	Moose::Meta::Method::Constructor::new("Moose::Meta::Method::Constructor", "options", HASH(0x295f150), "metaclass", Moose::Meta::Class=HASH(0x2d57938), "is_inline", 1, "package_name", "ImmutableClass", ...) called at ../moose/blib/lib/Class/MOP/Class.pm line 1453
    	Class::MOP::Class::_inline_constructor(Moose::Meta::Class=HASH(0x2d57938), "constructor_class", "Moose::Meta::Method::Constructor", "line", 36, "inline_destructor", 1, "constructor_name", "new", ...) called at ../moose/blib/lib/Class/MOP/Class.pm line 1409
    	Class::MOP::Class::_install_inlined_code(Moose::Meta::Class=HASH(0x2d57938), "immutable_trait", "Class::MOP::Class::Immutable::Trait", "inline_constructor", 1, "inline_accessors", 0, "debug", 0, ...) called at ../moose/blib/lib/Class/MOP/Class.pm line 1401
    	Class::MOP::Class::_initialize_immutable(Moose::Meta::Class=HASH(0x2d57938), "file", "t/basic.t", "line", 36, "inline_accessors", 1, "inline_constructor", 1, ...) called at ../moose/blib/lib/Class/MOP/Class.pm line 1297
    	Class::MOP::Class::make_immutable(Moose::Meta::Class=HASH(0x2d57938)) called at t/basic.t line 36
    $VAR1 = [
              'if (! (( do { ( do { ( do { defined($default) } ) && !ref($default) } ) && (my $val = $default) =~ /\\A-?[0-9]+\\z/ } ))) {',
              'my $msg = do { local $_ = $default; $type_constraint_messages[3]->($default);};
    die Module::Runtime::use_module("Moose::Exception::ValidationFailedForInlineTypeConstraint")->new(type_constraint_message => $msg , class_name              => $class_name, attribute_name          => "d",value                   => $default);',
              '}'
            ];
     at ../moose/blib/lib/Class/MOP/Method/Wrapped.pm line 158.
    	Class::MOP::Method::Wrapped::__ANON__(Moose::Meta::Class::__ANON__::SERIAL::1=HASH(0x2d65190), "\$default", "\$type_constraint_bodies[3]", "\$type_constraint_messages[3]", undef) called at ../moose/blib/lib/Class/MOP/Method/Wrapped.pm line 87
    	Moose::Meta::Class::__ANON__::SERIAL::1::_inline_check_constraint(Moose::Meta::Class::__ANON__::SERIAL::1=HASH(0x2d65190), "\$default", "\$type_constraint_bodies[3]", "\$type_constraint_messages[3]", undef) called at ../moose/blib/lib/Moose/Meta/Attribute.pm line 650
    	Moose::Meta::Attribute::_inline_tc_code(Moose::Meta::Class::__ANON__::SERIAL::1=HASH(0x2d65190), "\$default", "\$type_constraint_bodies[3]", "\$type_coercions[3]", "\$type_constraint_messages[3]") called at ../moose/blib/lib/Moose/Meta/Attribute.pm line 596
    	Moose::Meta::Attribute::_inline_set_value(Moose::Meta::Class::__ANON__::SERIAL::1=HASH(0x2d65190), "\$instance", "\$default", "\$type_constraint_bodies[3]", "\$type_coercions[3]", "\$type_constraint_messages[3]", "for constructor") called at ../moose/blib/lib/Moose/Meta/Class.pm line 425
    	Moose::Meta::Class::_inline_init_attr_from_default(Moose::Meta::Class=HASH(0x2d57938), Moose::Meta::Class::__ANON__::SERIAL::1=HASH(0x2d65190), 3) called at ../moose/blib/lib/Class/MOP/Class.pm line 606
    	Class::MOP::Class::_inline_slot_initializer(Moose::Meta::Class=HASH(0x2d57938), Moose::Meta::Class::__ANON__::SERIAL::1=HASH(0x2d65190), 3) called at ../moose/blib/lib/Moose/Meta/Class.pm line 365
    	Moose::Meta::Class::_inline_slot_initializer(Moose::Meta::Class=HASH(0x2d57938), Moose::Meta::Class::__ANON__::SERIAL::1=HASH(0x2d65190), 3) called at ../moose/blib/lib/Class/MOP/Class.pm line 592
    	Class::MOP::Class::_inline_slot_initializers(Moose::Meta::Class=HASH(0x2d57938)) called at ../moose/blib/lib/Class/MOP/Class.pm line 538
    	Class::MOP::Class::_inline_new_object(Moose::Meta::Class=HASH(0x2d57938)) called at ../moose/blib/lib/Class/MOP/Method/Constructor.pm line 98
    	Class::MOP::Method::Constructor::_generate_constructor_method_inline(Moose::Meta::Method::Constructor=HASH(0x2d577d0)) called at ../moose/blib/lib/Moose/Meta/Method/Constructor.pm line 54
    	Moose::Meta::Method::Constructor::_initialize_body(Moose::Meta::Method::Constructor=HASH(0x2d577d0)) called at ../moose/blib/lib/Moose/Meta/Method/Constructor.pm line 45
    	Moose::Meta::Method::Constructor::new("Moose::Meta::Method::Constructor", "options", HASH(0x295f150), "metaclass", Moose::Meta::Class=HASH(0x2d57938), "is_inline", 1, "package_name", "ImmutableClass", ...) called at ../moose/blib/lib/Class/MOP/Class.pm line 1453
    	Class::MOP::Class::_inline_constructor(Moose::Meta::Class=HASH(0x2d57938), "constructor_class", "Moose::Meta::Method::Constructor", "line", 36, "inline_destructor", 1, "constructor_name", "new", ...) called at ../moose/blib/lib/Class/MOP/Class.pm line 1409
    	Class::MOP::Class::_install_inlined_code(Moose::Meta::Class=HASH(0x2d57938), "immutable_trait", "Class::MOP::Class::Immutable::Trait", "inline_constructor", 1, "inline_accessors", 0, "debug", 0, ...) called at ../moose/blib/lib/Class/MOP/Class.pm line 1401
    	Class::MOP::Class::_initialize_immutable(Moose::Meta::Class=HASH(0x2d57938), "file", "t/basic.t", "line", 36, "inline_accessors", 1, "inline_constructor", 1, ...) called at ../moose/blib/lib/Class/MOP/Class.pm line 1297
    	Class::MOP::Class::make_immutable(Moose::Meta::Class=HASH(0x2d57938)) called at t/basic.t line 36
    $VAR1 = [
              'if (! (( do { ( do { ( do { defined($_[1]) } ) && !ref($_[1]) } ) && (my $val = $_[1]) =~ /\\A-?[0-9]+\\z/ } ))) {',
              'my $msg = do { local $_ = $_[1]; $type_message->($_[1]);};
    die Module::Runtime::use_module("Moose::Exception::ValidationFailedForInlineTypeConstraint")->new(type_constraint_message => $msg , class_name              => $class_name, attribute_name          => "c",value                   => $_[1]);',
              '}'
            ];
     at ../moose/blib/lib/Class/MOP/Method/Wrapped.pm line 158.
    	Class::MOP::Method::Wrapped::__ANON__(Moose::Meta::Class::__ANON__::SERIAL::1=HASH(0x2da9b90), "\$_[1]", "\$type_constraint", "\$type_message", undef) called at ../moose/blib/lib/Class/MOP/Method/Wrapped.pm line 87
    	Moose::Meta::Class::__ANON__::SERIAL::1::_inline_check_constraint(Moose::Meta::Class::__ANON__::SERIAL::1=HASH(0x2da9b90), "\$_[1]", "\$type_constraint", "\$type_message", undef) called at ../moose/blib/lib/Moose/Meta/Attribute.pm line 650
    	Moose::Meta::Attribute::_inline_tc_code(Moose::Meta::Class::__ANON__::SERIAL::1=HASH(0x2da9b90), "\$_[1]", "\$type_constraint", "\$type_coercion", "\$type_message") called at ../moose/blib/lib/Moose/Meta/Attribute.pm line 596
    	Moose::Meta::Attribute::_inline_set_value(Moose::Meta::Class::__ANON__::SERIAL::1=HASH(0x2da9b90), "\$_[0]", "\$_[1]") called at ../moose/blib/lib/Class/MOP/Method/Accessor.pm line 113
    	Class::MOP::Method::Accessor::try {...} () called at /home/avar/perl5/installed/lib/site_perl/5.18.2/Try/Tiny.pm line 76
    	eval {...} called at /home/avar/perl5/installed/lib/site_perl/5.18.2/Try/Tiny.pm line 72
    	Try::Tiny::try(CODE(0x2da4618), Try::Tiny::Catch=REF(0x2da9fb0)) called at ../moose/blib/lib/Class/MOP/Method/Accessor.pm line 127
    	Class::MOP::Method::Accessor::_generate_accessor_method_inline(Moose::Meta::Method::Accessor=HASH(0x2da4648)) called at ../moose/blib/lib/Moose/Meta/Method/Accessor.pm line 68
    	Moose::Meta::Method::Accessor::_generate_accessor_method(Moose::Meta::Method::Accessor=HASH(0x2da4648)) called at ../moose/blib/lib/Class/MOP/Method/Accessor.pm line 91
    	Class::MOP::Method::Accessor::_initialize_body(Moose::Meta::Method::Accessor=HASH(0x2da4648)) called at ../moose/blib/lib/Class/MOP/Method/Accessor.pm line 43
    	Class::MOP::Method::Accessor::new("Moose::Meta::Method::Accessor", "attribute", Moose::Meta::Class::__ANON__::SERIAL::1=HASH(0x2da9b90), "is_inline", undef, "accessor_type", "accessor", "package_name", "RwClass", ...) called at ../moose/blib/lib/Class/MOP/Attribute.pm line 407
    	Class::MOP::Attribute::try {...} () called at /home/avar/perl5/installed/lib/site_perl/5.18.2/Try/Tiny.pm line 81
    	eval {...} called at /home/avar/perl5/installed/lib/site_perl/5.18.2/Try/Tiny.pm line 72
    	Try::Tiny::try(CODE(0x2da9a58), Try::Tiny::Catch=REF(0x2da9aa0)) called at ../moose/blib/lib/Class/MOP/Attribute.pm line 423
    	Class::MOP::Attribute::_process_accessors(Moose::Meta::Class::__ANON__::SERIAL::1=HASH(0x2da9b90), "accessor", "c", undef) called at ../moose/blib/lib/Moose/Meta/Attribute.pm line 1059
    	Moose::Meta::Attribute::_process_accessors(Moose::Meta::Class::__ANON__::SERIAL::1=HASH(0x2da9b90), "accessor", "c", undef) called at ../moose/blib/lib/Class/MOP/Attribute.pm line 446
    	Class::MOP::Attribute::install_accessors(Moose::Meta::Class::__ANON__::SERIAL::1=HASH(0x2da9b90)) called at ../moose/blib/lib/Moose/Meta/Attribute.pm line 998
    	Moose::Meta::Attribute::install_accessors(Moose::Meta::Class::__ANON__::SERIAL::1=HASH(0x2da9b90)) called at ../moose/blib/lib/Class/MOP/Class.pm line 899
    	Class::MOP::Class::try {...} () called at /home/avar/perl5/installed/lib/site_perl/5.18.2/Try/Tiny.pm line 81
    	eval {...} called at /home/avar/perl5/installed/lib/site_perl/5.18.2/Try/Tiny.pm line 72
    	Try::Tiny::try(CODE(0x2da4a08), Try::Tiny::Catch=REF(0x2d709b0)) called at ../moose/blib/lib/Class/MOP/Class.pm line 904
    	Class::MOP::Class::_post_add_attribute(Moose::Meta::Class=HASH(0x2b52d10), Moose::Meta::Class::__ANON__::SERIAL::1=HASH(0x2da9b90)) called at ../moose/blib/lib/Class/MOP/Mixin/HasAttributes.pm line 39
    	Class::MOP::Mixin::HasAttributes::add_attribute(Moose::Meta::Class=HASH(0x2b52d10), Moose::Meta::Class::__ANON__::SERIAL::1=HASH(0x2da9b90)) called at ../moose/blib/lib/Moose/Meta/Class.pm line 573
    	Moose::Meta::Class::add_attribute(Moose::Meta::Class=HASH(0x2b52d10), "c", "definition_context", HASH(0x2d1ca50), "is", "rw", "isa", MooseX::Types::TypeDecorator=HASH(0x2d67040), "default", ...) called at ../moose/blib/lib/Moose.pm line 76
    	Moose::has(Moose::Meta::Class=HASH(0x2b52d10), "c", "is", "rw", "isa", MooseX::Types::TypeDecorator=HASH(0x2d67040), "default", 12345, "traits", ...) called at ../moose/blib/lib/Moose/Exporter.pm line 419
    	Moose::has("c", "is", "rw", "isa", MooseX::Types::TypeDecorator=HASH(0x2d67040), "default", 12345, "traits", ARRAY(0x2d658c8), ...) called at t/basic.t line 52
    $VAR1 = [
              'if (! (( do { ( do { ( do { defined($_[1]) } ) && !ref($_[1]) } ) && (my $val = $_[1]) =~ /\\A-?[0-9]+\\z/ } ))) {',
              'my $msg = do { local $_ = $_[1]; $type_message->($_[1]);};
    die Module::Runtime::use_module("Moose::Exception::ValidationFailedForInlineTypeConstraint")->new(type_constraint_message => $msg , class_name              => $class_name, attribute_name          => "d",value                   => $_[1]);',
              '}'
            ];
     at ../moose/blib/lib/Class/MOP/Method/Wrapped.pm line 158.
    	Class::MOP::Method::Wrapped::__ANON__(Moose::Meta::Class::__ANON__::SERIAL::1=HASH(0x2da9ba8), "\$_[1]", "\$type_constraint", "\$type_message", undef) called at ../moose/blib/lib/Class/MOP/Method/Wrapped.pm line 87
    	Moose::Meta::Class::__ANON__::SERIAL::1::_inline_check_constraint(Moose::Meta::Class::__ANON__::SERIAL::1=HASH(0x2da9ba8), "\$_[1]", "\$type_constraint", "\$type_message", undef) called at ../moose/blib/lib/Moose/Meta/Attribute.pm line 650
    	Moose::Meta::Attribute::_inline_tc_code(Moose::Meta::Class::__ANON__::SERIAL::1=HASH(0x2da9ba8), "\$_[1]", "\$type_constraint", "\$type_coercion", "\$type_message") called at ../moose/blib/lib/Moose/Meta/Attribute.pm line 596
    	Moose::Meta::Attribute::_inline_set_value(Moose::Meta::Class::__ANON__::SERIAL::1=HASH(0x2da9ba8), "\$_[0]", "\$_[1]") called at ../moose/blib/lib/Class/MOP/Method/Accessor.pm line 113
    	Class::MOP::Method::Accessor::try {...} () called at /home/avar/perl5/installed/lib/site_perl/5.18.2/Try/Tiny.pm line 76
    	eval {...} called at /home/avar/perl5/installed/lib/site_perl/5.18.2/Try/Tiny.pm line 72
    	Try::Tiny::try(CODE(0x2da4858), Try::Tiny::Catch=REF(0x2da9980)) called at ../moose/blib/lib/Class/MOP/Method/Accessor.pm line 127
    	Class::MOP::Method::Accessor::_generate_accessor_method_inline(Moose::Meta::Method::Accessor=HASH(0x2da4810)) called at ../moose/blib/lib/Moose/Meta/Method/Accessor.pm line 68
    	Moose::Meta::Method::Accessor::_generate_accessor_method(Moose::Meta::Method::Accessor=HASH(0x2da4810)) called at ../moose/blib/lib/Class/MOP/Method/Accessor.pm line 91
    	Class::MOP::Method::Accessor::_initialize_body(Moose::Meta::Method::Accessor=HASH(0x2da4810)) called at ../moose/blib/lib/Class/MOP/Method/Accessor.pm line 43
    	Class::MOP::Method::Accessor::new("Moose::Meta::Method::Accessor", "attribute", Moose::Meta::Class::__ANON__::SERIAL::1=HASH(0x2da9ba8), "is_inline", undef, "accessor_type", "accessor", "package_name", "RwClass", ...) called at ../moose/blib/lib/Class/MOP/Attribute.pm line 407
    	Class::MOP::Attribute::try {...} () called at /home/avar/perl5/installed/lib/site_perl/5.18.2/Try/Tiny.pm line 81
    	eval {...} called at /home/avar/perl5/installed/lib/site_perl/5.18.2/Try/Tiny.pm line 72
    	Try::Tiny::try(CODE(0x2da44b0), Try::Tiny::Catch=REF(0x2da4750)) called at ../moose/blib/lib/Class/MOP/Attribute.pm line 423
    	Class::MOP::Attribute::_process_accessors(Moose::Meta::Class::__ANON__::SERIAL::1=HASH(0x2da9ba8), "accessor", "d", undef) called at ../moose/blib/lib/Moose/Meta/Attribute.pm line 1059
    	Moose::Meta::Attribute::_process_accessors(Moose::Meta::Class::__ANON__::SERIAL::1=HASH(0x2da9ba8), "accessor", "d", undef) called at ../moose/blib/lib/Class/MOP/Attribute.pm line 446
    	Class::MOP::Attribute::install_accessors(Moose::Meta::Class::__ANON__::SERIAL::1=HASH(0x2da9ba8)) called at ../moose/blib/lib/Moose/Meta/Attribute.pm line 998
    	Moose::Meta::Attribute::install_accessors(Moose::Meta::Class::__ANON__::SERIAL::1=HASH(0x2da9ba8)) called at ../moose/blib/lib/Class/MOP/Class.pm line 899
    	Class::MOP::Class::try {...} () called at /home/avar/perl5/installed/lib/site_perl/5.18.2/Try/Tiny.pm line 81
    	eval {...} called at /home/avar/perl5/installed/lib/site_perl/5.18.2/Try/Tiny.pm line 72
    	Try::Tiny::try(CODE(0x2daa2f8), Try::Tiny::Catch=REF(0x2da9a40)) called at ../moose/blib/lib/Class/MOP/Class.pm line 904
    	Class::MOP::Class::_post_add_attribute(Moose::Meta::Class=HASH(0x2b52d10), Moose::Meta::Class::__ANON__::SERIAL::1=HASH(0x2da9ba8)) called at ../moose/blib/lib/Class/MOP/Mixin/HasAttributes.pm line 39
    	Class::MOP::Mixin::HasAttributes::add_attribute(Moose::Meta::Class=HASH(0x2b52d10), Moose::Meta::Class::__ANON__::SERIAL::1=HASH(0x2da9ba8)) called at ../moose/blib/lib/Moose/Meta/Class.pm line 573
    	Moose::Meta::Class::add_attribute(Moose::Meta::Class=HASH(0x2b52d10), "d", "definition_context", HASH(0x2971228), "is", "rw", "isa", MooseX::Types::TypeDecorator=HASH(0x2d66440), "default", ...) called at ../moose/blib/lib/Moose.pm line 76
    	Moose::has(Moose::Meta::Class=HASH(0x2b52d10), "d", "is", "rw", "isa", MooseX::Types::TypeDecorator=HASH(0x2d66440), "default", 12345, "traits", ...) called at ../moose/blib/lib/Moose/Exporter.pm line 419
    	Moose::has("d", "is", "rw", "isa", MooseX::Types::TypeDecorator=HASH(0x2d66440), "default", 12345, "traits", ARRAY(0x2d70a10), ...) called at t/basic.t line 52
    $VAR1 = [
              'if (! (( do { ( do { ( do { defined($_[1]) } ) && !ref($_[1]) } ) && (my $val = $_[1]) =~ /\\A-?[0-9]+\\z/ } ))) {',
              'my $msg = do { local $_ = $_[1]; $type_message->($_[1]);};
    die Module::Runtime::use_module("Moose::Exception::ValidationFailedForInlineTypeConstraint")->new(type_constraint_message => $msg , class_name              => $class_name, attribute_name          => "b",value                   => $_[1]);',
              '}'
            ];
     at ../moose/blib/lib/Class/MOP/Method/Wrapped.pm line 158.
    	Class::MOP::Method::Wrapped::__ANON__(Moose::Meta::Class::__ANON__::SERIAL::1=HASH(0x2db4dc0), "\$_[1]", "\$type_constraint", "\$type_message", undef) called at ../moose/blib/lib/Class/MOP/Method/Wrapped.pm line 87
    	Moose::Meta::Class::__ANON__::SERIAL::1::_inline_check_constraint(Moose::Meta::Class::__ANON__::SERIAL::1=HASH(0x2db4dc0), "\$_[1]", "\$type_constraint", "\$type_message", undef) called at ../moose/blib/lib/Moose/Meta/Attribute.pm line 650
    	Moose::Meta::Attribute::_inline_tc_code(Moose::Meta::Class::__ANON__::SERIAL::1=HASH(0x2db4dc0), "\$_[1]", "\$type_constraint", "\$type_coercion", "\$type_message") called at ../moose/blib/lib/Moose/Meta/Attribute.pm line 596
    	Moose::Meta::Attribute::_inline_set_value(Moose::Meta::Class::__ANON__::SERIAL::1=HASH(0x2db4dc0), "\$_[0]", "\$_[1]") called at ../moose/blib/lib/Class/MOP/Method/Accessor.pm line 113
    	Class::MOP::Method::Accessor::try {...} () called at /home/avar/perl5/installed/lib/site_perl/5.18.2/Try/Tiny.pm line 76
    	eval {...} called at /home/avar/perl5/installed/lib/site_perl/5.18.2/Try/Tiny.pm line 72
    	Try::Tiny::try(CODE(0x2da99c8), Try::Tiny::Catch=REF(0x2da9938)) called at ../moose/blib/lib/Class/MOP/Method/Accessor.pm line 127
    	Class::MOP::Method::Accessor::_generate_accessor_method_inline(Moose::Meta::Method::Accessor=HASH(0x2da9770)) called at ../moose/blib/lib/Moose/Meta/Method/Accessor.pm line 68
    	Moose::Meta::Method::Accessor::_generate_accessor_method(Moose::Meta::Method::Accessor=HASH(0x2da9770)) called at ../moose/blib/lib/Class/MOP/Method/Accessor.pm line 91
    	Class::MOP::Method::Accessor::_initialize_body(Moose::Meta::Method::Accessor=HASH(0x2da9770)) called at ../moose/blib/lib/Class/MOP/Method/Accessor.pm line 43
    	Class::MOP::Method::Accessor::new("Moose::Meta::Method::Accessor", "attribute", Moose::Meta::Class::__ANON__::SERIAL::1=HASH(0x2db4dc0), "is_inline", undef, "accessor_type", "accessor", "package_name", "RwClass", ...) called at ../moose/blib/lib/Class/MOP/Attribute.pm line 407
    	Class::MOP::Attribute::try {...} () called at /home/avar/perl5/installed/lib/site_perl/5.18.2/Try/Tiny.pm line 81
    	eval {...} called at /home/avar/perl5/installed/lib/site_perl/5.18.2/Try/Tiny.pm line 72
    	Try::Tiny::try(CODE(0x2db49a0), Try::Tiny::Catch=REF(0x2da9620)) called at ../moose/blib/lib/Class/MOP/Attribute.pm line 423
    	Class::MOP::Attribute::_process_accessors(Moose::Meta::Class::__ANON__::SERIAL::1=HASH(0x2db4dc0), "accessor", "b", undef) called at ../moose/blib/lib/Moose/Meta/Attribute.pm line 1059
    	Moose::Meta::Attribute::_process_accessors(Moose::Meta::Class::__ANON__::SERIAL::1=HASH(0x2db4dc0), "accessor", "b", undef) called at ../moose/blib/lib/Class/MOP/Attribute.pm line 446
    	Class::MOP::Attribute::install_accessors(Moose::Meta::Class::__ANON__::SERIAL::1=HASH(0x2db4dc0)) called at ../moose/blib/lib/Moose/Meta/Attribute.pm line 998
    	Moose::Meta::Attribute::install_accessors(Moose::Meta::Class::__ANON__::SERIAL::1=HASH(0x2db4dc0)) called at ../moose/blib/lib/Class/MOP/Class.pm line 899
    	Class::MOP::Class::try {...} () called at /home/avar/perl5/installed/lib/site_perl/5.18.2/Try/Tiny.pm line 81
    	eval {...} called at /home/avar/perl5/installed/lib/site_perl/5.18.2/Try/Tiny.pm line 72
    	Try::Tiny::try(CODE(0x2da9c20), Try::Tiny::Catch=REF(0x2db4838)) called at ../moose/blib/lib/Class/MOP/Class.pm line 904
    	Class::MOP::Class::_post_add_attribute(Moose::Meta::Class=HASH(0x2b52d10), Moose::Meta::Class::__ANON__::SERIAL::1=HASH(0x2db4dc0)) called at ../moose/blib/lib/Class/MOP/Mixin/HasAttributes.pm line 39
    	Class::MOP::Mixin::HasAttributes::add_attribute(Moose::Meta::Class=HASH(0x2b52d10), Moose::Meta::Class::__ANON__::SERIAL::1=HASH(0x2db4dc0)) called at ../moose/blib/lib/Moose/Meta/Class.pm line 573
    	Moose::Meta::Class::add_attribute(Moose::Meta::Class=HASH(0x2b52d10), "b", "definition_context", HASH(0x2d671f0), "is", "rw", "isa", MooseX::Types::TypeDecorator=HASH(0x2d658c8), "default", ...) called at ../moose/blib/lib/Moose.pm line 76
    	Moose::has(Moose::Meta::Class=HASH(0x2b52d10), "b", "is", "rw", "isa", MooseX::Types::TypeDecorator=HASH(0x2d658c8), "default", 12345, "traits", ...) called at ../moose/blib/lib/Moose/Exporter.pm line 419
    	Moose::has("b", "is", "rw", "isa", MooseX::Types::TypeDecorator=HASH(0x2d658c8), "default", 12345, "traits", ARRAY(0x2d67238), ...) called at t/basic.t line 52
    $VAR1 = [
              'if (! (( do { ( do { ( do { defined($_[1]) } ) && !ref($_[1]) } ) && (my $val = $_[1]) =~ /\\A-?[0-9]+\\z/ } ))) {',
              'my $msg = do { local $_ = $_[1]; $type_message->($_[1]);};
    die Module::Runtime::use_module("Moose::Exception::ValidationFailedForInlineTypeConstraint")->new(type_constraint_message => $msg , class_name              => $class_name, attribute_name          => "a",value                   => $_[1]);',
              '}'
            ];
     at ../moose/blib/lib/Class/MOP/Method/Wrapped.pm line 158.
    	Class::MOP::Method::Wrapped::__ANON__(Moose::Meta::Class::__ANON__::SERIAL::1=HASH(0x2db7ae0), "\$_[1]", "\$type_constraint", "\$type_message", undef) called at ../moose/blib/lib/Class/MOP/Method/Wrapped.pm line 87
    	Moose::Meta::Class::__ANON__::SERIAL::1::_inline_check_constraint(Moose::Meta::Class::__ANON__::SERIAL::1=HASH(0x2db7ae0), "\$_[1]", "\$type_constraint", "\$type_message", undef) called at ../moose/blib/lib/Moose/Meta/Attribute.pm line 650
    	Moose::Meta::Attribute::_inline_tc_code(Moose::Meta::Class::__ANON__::SERIAL::1=HASH(0x2db7ae0), "\$_[1]", "\$type_constraint", "\$type_coercion", "\$type_message") called at ../moose/blib/lib/Moose/Meta/Attribute.pm line 596
    	Moose::Meta::Attribute::_inline_set_value(Moose::Meta::Class::__ANON__::SERIAL::1=HASH(0x2db7ae0), "\$_[0]", "\$_[1]") called at ../moose/blib/lib/Class/MOP/Method/Accessor.pm line 113
    	Class::MOP::Method::Accessor::try {...} () called at /home/avar/perl5/installed/lib/site_perl/5.18.2/Try/Tiny.pm line 76
    	eval {...} called at /home/avar/perl5/installed/lib/site_perl/5.18.2/Try/Tiny.pm line 72
    	Try::Tiny::try(CODE(0x2db4c88), Try::Tiny::Catch=REF(0x2db4640)) called at ../moose/blib/lib/Class/MOP/Method/Accessor.pm line 127
    	Class::MOP::Method::Accessor::_generate_accessor_method_inline(Moose::Meta::Method::Accessor=HASH(0x2db4c70)) called at ../moose/blib/lib/Moose/Meta/Method/Accessor.pm line 68
    	Moose::Meta::Method::Accessor::_generate_accessor_method(Moose::Meta::Method::Accessor=HASH(0x2db4c70)) called at ../moose/blib/lib/Class/MOP/Method/Accessor.pm line 91
    	Class::MOP::Method::Accessor::_initialize_body(Moose::Meta::Method::Accessor=HASH(0x2db4c70)) called at ../moose/blib/lib/Class/MOP/Method/Accessor.pm line 43
    	Class::MOP::Method::Accessor::new("Moose::Meta::Method::Accessor", "attribute", Moose::Meta::Class::__ANON__::SERIAL::1=HASH(0x2db7ae0), "is_inline", undef, "accessor_type", "accessor", "package_name", "RwClass", ...) called at ../moose/blib/lib/Class/MOP/Attribute.pm line 407
    	Class::MOP::Attribute::try {...} () called at /home/avar/perl5/installed/lib/site_perl/5.18.2/Try/Tiny.pm line 81
    	eval {...} called at /home/avar/perl5/installed/lib/site_perl/5.18.2/Try/Tiny.pm line 72
    	Try::Tiny::try(CODE(0x2da4510), Try::Tiny::Catch=REF(0x2db49e8)) called at ../moose/blib/lib/Class/MOP/Attribute.pm line 423
    	Class::MOP::Attribute::_process_accessors(Moose::Meta::Class::__ANON__::SERIAL::1=HASH(0x2db7ae0), "accessor", "a", undef) called at ../moose/blib/lib/Moose/Meta/Attribute.pm line 1059
    	Moose::Meta::Attribute::_process_accessors(Moose::Meta::Class::__ANON__::SERIAL::1=HASH(0x2db7ae0), "accessor", "a", undef) called at ../moose/blib/lib/Class/MOP/Attribute.pm line 446
    	Class::MOP::Attribute::install_accessors(Moose::Meta::Class::__ANON__::SERIAL::1=HASH(0x2db7ae0)) called at ../moose/blib/lib/Moose/Meta/Attribute.pm line 998
    	Moose::Meta::Attribute::install_accessors(Moose::Meta::Class::__ANON__::SERIAL::1=HASH(0x2db7ae0)) called at ../moose/blib/lib/Class/MOP/Class.pm line 899
    	Class::MOP::Class::try {...} () called at /home/avar/perl5/installed/lib/site_perl/5.18.2/Try/Tiny.pm line 81
    	eval {...} called at /home/avar/perl5/installed/lib/site_perl/5.18.2/Try/Tiny.pm line 72
    	Try::Tiny::try(CODE(0x2daa298), Try::Tiny::Catch=REF(0x2da96f8)) called at ../moose/blib/lib/Class/MOP/Class.pm line 904
    	Class::MOP::Class::_post_add_attribute(Moose::Meta::Class=HASH(0x2b52d10), Moose::Meta::Class::__ANON__::SERIAL::1=HASH(0x2db7ae0)) called at ../moose/blib/lib/Class/MOP/Mixin/HasAttributes.pm line 39
    	Class::MOP::Mixin::HasAttributes::add_attribute(Moose::Meta::Class=HASH(0x2b52d10), Moose::Meta::Class::__ANON__::SERIAL::1=HASH(0x2db7ae0)) called at ../moose/blib/lib/Moose/Meta/Class.pm line 573
    	Moose::Meta::Class::add_attribute(Moose::Meta::Class=HASH(0x2b52d10), "a", "definition_context", HASH(0x2d66488), "is", "rw", "isa", MooseX::Types::TypeDecorator=HASH(0x2d70a10), "default", ...) called at ../moose/blib/lib/Moose.pm line 76
    	Moose::has(Moose::Meta::Class=HASH(0x2b52d10), "a", "is", "rw", "isa", MooseX::Types::TypeDecorator=HASH(0x2d70a10), "default", 12345, "traits", ...) called at ../moose/blib/lib/Moose/Exporter.pm line 419
    	Moose::has("a", "is", "rw", "isa", MooseX::Types::TypeDecorator=HASH(0x2d70a10), "default", 12345, "traits", ARRAY(0x2d664a0), ...) called at t/basic.t line 52
    ok 1 - We got an error
    ok 2 - We got a warning
    ok 3 - We got an incorrect value with a warning
    ok 4 - We got a default
    ok 5 - We got a default value with default
    ok 6 - We didn't get a warning with default_no_warning
    ok 7 - We got a default value with default
    ok 8 - We got an error
    not ok 9 - Attribute (a) does not pass the type constraint because: Validation failed for 'Int' with value foo at constructor ImmutableClass::new (defined at t/basic.t line 36) line 32 # TODO Our _coerce_and_verify isn't called when you __PACKAGE__->meta->make_immutable
    #   Failed (TODO) test 'Attribute (a) does not pass the type constraint because: Validation failed for 'Int' with value foo at constructor ImmutableClass::new (defined at t/basic.t line 36) line 32'
    #   at t/basic.t line 148.
    not ok 10 - Attribute (b) does not pass the type constraint because: Validation failed for 'Int' with value foo at constructor ImmutableClass::new (defined at t/basic.t line 36) line 48 # TODO Our _coerce_and_verify isn't called when you __PACKAGE__->meta->make_immutable
    #   Failed (TODO) test 'Attribute (b) does not pass the type constraint because: Validation failed for 'Int' with value foo at constructor ImmutableClass::new (defined at t/basic.t line 36) line 48'
    #   at t/basic.t line 148.
    not ok 11 - Attribute (c) does not pass the type constraint because: Validation failed for 'Int' with value foo at constructor ImmutableClass::new (defined at t/basic.t line 36) line 64 # TODO Our _coerce_and_verify isn't called when you __PACKAGE__->meta->make_immutable
    #   Failed (TODO) test 'Attribute (c) does not pass the type constraint because: Validation failed for 'Int' with value foo at constructor ImmutableClass::new (defined at t/basic.t line 36) line 64'
    #   at t/basic.t line 148.
    ok 12 - We got an error on accessor as expected
    ok 13 - We got an error on accessor as expected
    ok 14 - We got an error on accessor as expected
    ok 15 - We got an error on accessor as expectedmoosex-attribute-typeconstraint-customizefatal